### PR TITLE
Fix -Wstrict-prototypes warnings on CRAN (functions without prototype…

### DIFF
--- a/src/kit.h
+++ b/src/kit.h
@@ -89,7 +89,7 @@ extern SEXP iifR(SEXP l, SEXP a, SEXP b, SEXP na, SEXP tprom, SEXP nthreads);
 extern SEXP nifR(SEXP na, SEXP rho, SEXP args);
 extern SEXP nifInternalR(SEXP na, SEXP rho, SEXP args);
 extern SEXP nswitchR(SEXP x, SEXP na, SEXP nthreads, SEXP chkenc, SEXP args);
-extern SEXP ompEnabledR();
+extern SEXP ompEnabledR(void);
 extern SEXP pallR(SEXP na, SEXP args);
 extern SEXP panyR(SEXP na, SEXP args);
 extern SEXP pcountR(SEXP x, SEXP args);

--- a/src/utils.c
+++ b/src/utils.c
@@ -18,7 +18,7 @@
 
 #include "kit.h"
 
-SEXP ompEnabledR() {
+SEXP ompEnabledR(void) {
   return omp_enabled ? ScalarLogical(TRUE) : ScalarLogical(FALSE);
 }
 


### PR DESCRIPTION
…s is depreciated in ISO C 2x).